### PR TITLE
Fix gradle configuration for compile dependency

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile 'net.portswigger.burp.extender:burp-extender-api:1.7.13'
+    implementation 'net.portswigger.burp.extender:burp-extender-api:1.7.13'
 }
 
 sourceSets {


### PR DESCRIPTION
The `compile`, `runtime`, `testCompile`, and `testRuntime` configurations introduced by the Java plugin have been deprecated since [Gradle 4.0](https://docs.gradle.org/4.10/userguide/java_plugin.html#sec:java_plugin_and_dependency_management) (Aug 27, 2018), and were finally rremoved in [Gradle 7.0](https://docs.gradle.org/7.0/userguide/java_library_plugin.html#sec:java_library_configurations_graph) (Apr 9, 2021).

The aforementioned configurations should be replaced by `implementation`, `runtimeOnly`, `testImplementation`, and `testRuntimeOnly`, respectively.

Credits: https://stackoverflow.com/questions/23796404/could-not-find-method-compile-for-arguments-gradle/66910991#66910991